### PR TITLE
Add Terraform Infrastructure for AWS Amplify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,33 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Terraform files
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+
+# Local variable files
+terraform.tfvars
+*.tfvars
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars*
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan* 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -37,3 +37,6 @@ terraform destroy
 Due to changes in Amplify authentication methods to GitHub, then migration of the app might hang. If this happens comment out the repository in the `main.tf` and manually set up the connection. 
 
 The most important part of the terraform spec is for resource management.
+
+## Resources
+https://aws.amazon.com/getting-started/hands-on/build-react-app-amplify-graphql/module-one/

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,34 @@
+# Terraform Infrastructure for ProximaAI
+
+Terraform configuration for AWS Amplify deployment.
+
+## Step 1: Initial Deployment
+
+```bash
+cd terraform
+terraform init
+export TF_VAR_github_access_token="your_token"
+terraform apply
+```
+
+## Step 2: Migrate to GitHub App
+
+**Warning**: AWS now recommends GitHub Apps over Personal Access Tokens.
+
+1. Go to Amplify Console → Your App → App Settings → Repository
+2. Click "Disconnect repository"
+3. Reconnect using "GitHub" → Authorize GitHub App
+4. Select repository: `loaizasteven/ProximaAI`
+
+## Configuration
+
+- **Region**: us-east-1
+- **App**: ProximaAI Application
+- **Repository**: loaizasteven/ProximaAI
+- **Build**: react-ui directory
+
+## Cleanup
+
+```bash
+terraform destroy
+``` 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -32,3 +32,8 @@ terraform apply
 ```bash
 terraform destroy
 ``` 
+
+## Warning
+Due to changes in Amplify authentication methods to GitHub, then migration of the app might hang. If this happens comment out the repository in the `main.tf` and manually set up the connection. 
+
+The most important part of the terraform spec is for resource management.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-    region = "us-east-2"  # Set your desired region
+    region = "us-east-1"  # Set your desired region
 }
 
 variable "github_access_token" {
@@ -40,7 +40,7 @@ resource "aws_iam_role_policy_attachment" "terraform_amplify" {
 resource "aws_iam_role_policy" "terraform_minimal" {
     name = "terraform-minimal-policy"
     role = aws_iam_role.terraform_role.id
-
+    depends_on = [aws_iam_role.terraform_role]
     policy = jsonencode({
         "Version": "2012-10-17",
         "Statement": [

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,88 @@
+provider "aws" {
+    region = "us-west-2"  # Set your desired region
+}
+
+# Create a minimal IAM role with essential permissions
+resource "aws_iam_role" "terraform_role" {
+    name = "aws-amplify-terraform-role"
+    assume_role_policy = jsonencode({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "cloudformation.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+            }
+        ]
+    })
+}
+
+# Attach managed policies instead of inline policies
+resource "aws_iam_role_policy_attachment" "terraform_cloudformation" {
+    role       = aws_iam_role.terraform_role.name
+    policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_amplify" {
+    role       = aws_iam_role.terraform_role.name
+    policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess-Amplify"
+}
+
+# Minimal inline policy for specific permissions not covered by managed policies
+resource "aws_iam_role_policy" "terraform_minimal" {
+    name = "terraform-minimal-policy"
+    role = aws_iam_role.terraform_role.id
+
+    policy = jsonencode({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateRole",
+                    "iam:DeleteRole",
+                    "iam:PassRole",
+                    "iam:AttachRolePolicy",
+                    "iam:DetachRolePolicy",
+                    "iam:PutRolePolicy",
+                    "iam:DeleteRolePolicy"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:CreateBucket",
+                    "s3:DeleteBucket",
+                    "s3:PutBucketPolicy",
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:ListBucket"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "lambda:CreateFunction",
+                    "lambda:DeleteFunction",
+                    "lambda:UpdateFunctionCode",
+                    "lambda:AddPermission"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "cognito-idp:CreateUserPool",
+                    "cognito-idp:DeleteUserPool",
+                    "cognito-idp:CreateUserPoolClient",
+                    "cognito-idp:DeleteUserPoolClient"
+                ],
+                "Resource": "*"
+            }
+        ]
+    })
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-    region = "us-west-2"  # Set your desired region
+    region = "us-east-2"  # Set your desired region
 }
 
 variable "github_access_token" {


### PR DESCRIPTION
# Add Terraform Infrastructure for AWS Amplify

## Changes
- Add Terraform configuration for AWS Amplify deployment
- Create minimal IAM roles with managed policies
- Set up Amplify app with monorepo build spec
- Add GitHub integration support

## Files Added
- `terraform/main.tf` - Main infrastructure configuration
- `terraform/README.md` - Deployment instructions
- `terraform/terraform.tfvars.example` - Example variables

## Key Features
- Minimal IAM permissions to avoid ACL size limits
- Support for both GitHub App and Personal Access Token
- Monorepo build configuration for react-ui
- Step-by-step migration guide to GitHub App

## Warning
Due to Amplify's GitHub authentication changes, repository connection may need manual setup after initial deployment.

**Type:** Infrastructure
**Breaking Changes:** None