### PR TITLE
Add FastAPI Lifespan Management for MCP Server Integration

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -4,5 +4,8 @@
       "main_agent": "./src/proximaai/orchestrator/main_agent.py:create_orchestrator_agent"            
     },
     "env": "./.env",                                        
-    "python_version": "3.11"
-  }
+    "python_version": "3.11",
+    "http": {
+        "app": "./src/proximaai/mcp/server.py:app"
+    }
+}

--- a/langgraph.json
+++ b/langgraph.json
@@ -6,6 +6,7 @@
     "env": "./.env",                                        
     "python_version": "3.11",
     "http": {
-        "app": "./src/proximaai/mcp/server.py:app"
+        "app": "./src/proximaai/mcp/server.py:app",
+        "timeout": 10000
     }
 }

--- a/src/proximaai/mcp/llama_parse_server.py
+++ b/src/proximaai/mcp/llama_parse_server.py
@@ -23,7 +23,7 @@ async def file_to_bytesio(file_path):
 )
 async def parse_document(
     ctx: Context, 
-    file_path: str,
+    file_path: Union[os.PathLike, str, io.BytesIO],
     project_id: Union[str, None] = os.getenv("LLAMA_CLOUD_PROJECT_ID"),
     org_id: Union[str, None] = os.getenv("LLAMA_CLOUD_ORG_ID")
     ) -> Any:
@@ -36,9 +36,14 @@ async def parse_document(
         llama_parse = LlamaParse(organization_id=org_id, project_id=project_id)
 
         # Non-blocking file read
-        file_like = await file_to_bytesio(file_path)
-        result = await llama_parse.aparse(file_like, extra_info={"file_name": file_path.split("/")[-1]})
-
+        if isinstance(file_path, os.PathLike):
+            file_like = await file_to_bytesio(file_path)
+            file_name = file_path
+        else:
+            file_like = file_path
+            file_name = "default_resume.pdf"
+        result = await llama_parse.aparse(file_like, extra_info={"file_name": file_name})
+            
         if isinstance(result, JobResult):
             markdown = await result.aget_markdown_documents()
             text = [doc.text for doc in markdown]

--- a/src/proximaai/mcp/llama_parse_server.py
+++ b/src/proximaai/mcp/llama_parse_server.py
@@ -1,0 +1,50 @@
+import os
+import io
+
+from typing import Any, Union
+from mcp.server.fastmcp import FastMCP, Context
+from llama_cloud_services import LlamaParse
+import aiofiles
+
+# --- MCP Server Setup ---
+llama_parse_mcp = FastMCP("llama-parse-server")
+
+async def file_to_bytesio(file_path):
+    """Read a file into a BytesIO object asynchronously."""
+    async with aiofiles.open(file_path, 'rb') as f:
+        content = await f.read()
+    return io.BytesIO(content)
+
+# --- Tool Registration using @mcp.tool Decorator ---
+@llama_parse_mcp.tool(
+    name="parse_document",
+    description="Parse a document using LlamaParse."
+)
+async def parse_document(
+    ctx: Context, 
+    file_path: str,
+    project_id: Union[str, None] = os.getenv("LLAMA_CLOUD_PROJECT_ID"),
+    org_id: Union[str, None] = os.getenv("LLAMA_CLOUD_ORG_ID")
+    ) -> Any:
+    """
+    Parse a document using a configured LlamaParse agent.
+    """
+    ctx = llama_parse_mcp.get_context()
+    try:
+        # Instantiate the LlamaParse agent
+        llama_parse = LlamaParse(organization_id=org_id, project_id=project_id)
+
+        # Non-blocking file read
+        file_like = await file_to_bytesio(file_path)
+        result = await llama_parse.aparse(file_like, extra_info={"file_name": file_path.split("/")[-1]})
+
+        return dir(result)
+
+    except Exception as e:
+        await ctx.error(f"Error parsing document: {str(e)}")
+        return f"Error parsing document: {str(e)}"
+
+# --- HTTP Streamable Server Startup ---
+if __name__ == "__main__":
+    # Start the MCP server with streamable HTTP transport
+    llama_parse_mcp.run(transport="streamable-http")

--- a/src/proximaai/mcp/llama_parse_server.py
+++ b/src/proximaai/mcp/llama_parse_server.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 import os
 import io
 
-from typing import Any, Union, List
+from typing import Any, Union
 from mcp.server.fastmcp import FastMCP, Context
 from llama_cloud_services import LlamaParse
 from llama_cloud_services.parse.types import JobResult
@@ -37,6 +38,8 @@ async def parse_document(
 
         # Non-blocking file read
         if isinstance(file_path, os.PathLike):
+            _type = Path(file_path).suffix
+            assert _type == ".pdf", f"FileTypeError: extension {_type} is not supported"
             file_like = await file_to_bytesio(file_path)
             file_name = file_path
         else:

--- a/src/proximaai/mcp/llama_parse_server.py
+++ b/src/proximaai/mcp/llama_parse_server.py
@@ -1,9 +1,10 @@
 import os
 import io
 
-from typing import Any, Union
+from typing import Any, Union, List
 from mcp.server.fastmcp import FastMCP, Context
 from llama_cloud_services import LlamaParse
+from llama_cloud_services.parse.types import JobResult
 import aiofiles
 
 # --- MCP Server Setup ---
@@ -38,7 +39,13 @@ async def parse_document(
         file_like = await file_to_bytesio(file_path)
         result = await llama_parse.aparse(file_like, extra_info={"file_name": file_path.split("/")[-1]})
 
-        return dir(result)
+        if isinstance(result, JobResult):
+            markdown = await result.aget_markdown_documents()
+            text = [doc.text for doc in markdown]
+            return text
+        else:
+            raise ValueError(f"Unexpected result type: {type(result)}")
+        return 
 
     except Exception as e:
         await ctx.error(f"Error parsing document: {str(e)}")

--- a/src/proximaai/mcp/math_server.py
+++ b/src/proximaai/mcp/math_server.py
@@ -1,0 +1,9 @@
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(name="MathServer", stateless_http=True)
+
+
+@mcp.tool(description="A simple add tool")
+def add_two(n: int) -> int:
+    return n + 2
+    

--- a/src/proximaai/mcp/server.py
+++ b/src/proximaai/mcp/server.py
@@ -1,0 +1,23 @@
+import contextlib
+from fastapi import FastAPI
+from .math_server import mcp as math_mcp
+import os
+
+
+# Create a combined lifespan to manage both session managers
+@contextlib.asynccontextmanager
+async def lifespan(app: FastAPI):
+    async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(math_mcp.session_manager.run())
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+app.mount("/math", math_mcp.streamable_http_app())
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    PORT = int(os.environ.get("PORT", 10000))
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/src/proximaai/mcp/server.py
+++ b/src/proximaai/mcp/server.py
@@ -1,6 +1,6 @@
 import contextlib
 from fastapi import FastAPI
-from .math_server import mcp as math_mcp
+from proximaai.mcp.llama_parse_server import llama_parse_mcp
 import os
 
 
@@ -8,12 +8,12 @@ import os
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI):
     async with contextlib.AsyncExitStack() as stack:
-        await stack.enter_async_context(math_mcp.session_manager.run())
+        await stack.enter_async_context(llama_parse_mcp.session_manager.run())
         yield
 
 
 app = FastAPI(lifespan=lifespan)
-app.mount("/math", math_mcp.streamable_http_app())
+app.mount("/parse_document", llama_parse_mcp.streamable_http_app())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR implements proper FastAPI lifespan management to handle MCP (Model Context Protocol) server lifecycle, enabling seamless integration with LangGraph's HTTP deployment capabilities.

## Changes Made

### 🔧 **Core Implementation**
- **Added FastAPI lifespan context manager** in `src/proximaai/mcp/server.py`
- **Integrated MCP session management** using `AsyncExitStack` for proper resource cleanup
- **llama_parse server** for document processing capabilities

### 📋 **Configuration Updates**
- **Enhanced `langgraph.json`** with HTTP app configuration:
  - Added `http.app` pointing to the FastAPI application
  - Set `timeout: 10000` for proper request handling
  - Enables LangGraph to serve the MCP server alongside the main agent

### 🏗️ **Architecture Improvements**
- **Proper resource management**: MCP session managers are now properly initialized and cleaned up
- **HTTP route mounting**: Document parsing endpoint available at `/parse_document`
- **Production-ready deployment**: Compatible with LangGraph's cloud deployment

## Technical Details

**Lifespan Implementation:**
```python
@contextlib.asynccontextmanager
async def lifespan(app: FastAPI):
    async with contextlib.AsyncExitStack() as stack:
        await stack.enter_async_context(llama_parse_mcp.session_manager.run())
        yield
```

**LangGraph Configuration:**
```json
{
  "http": {
    "app": "./src/proximaai/mcp/server.py:app",
    "timeout": 10000
  }
}
```

---

**Files Changed:**
- `src/proximaai/mcp/server.py` - Added lifespan management
- `langgraph.json` - Added HTTP app configuration
- `src/proximaai/mcp/math_server.py` - Replaced with llama_parse integration